### PR TITLE
Implement Course → Module → Lesson hierarchy

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,8 +6,12 @@ import { ReferencesModule } from './references/references.module';
 import { Reference } from './entities/reference.entity';
 import { Module as CourseModule } from './entities/module.entity';
 import { Lesson } from './entities/lesson.entity';
+import { Course } from './entities/course.entity';
 import { UsersModule } from './users/users.module';
 import { User } from './users/entities/user.entity';
+import { CoursesModule } from './courses/courses.module';
+import { ModulesModule } from './modules/modules.module';
+import { LessonsModule } from './lessons/lessons.module';
 
 @Module({
   imports: [
@@ -18,11 +22,14 @@ import { User } from './users/entities/user.entity';
       username: process.env.DB_USERNAME || 'postgres',
       password: process.env.DB_PASSWORD || 'postgres',
       database: process.env.DB_DATABASE || 'skillcert',
-      entities: [Reference, CourseModule, Lesson, User],
+      entities: [Reference, CourseModule, Lesson, Course, User],
       synchronize: process.env.NODE_ENV !== 'production',
     }),
     ReferencesModule,
     UsersModule,
+    CoursesModule,
+    ModulesModule,
+    LessonsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Put,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { CoursesService } from './courses.service';
+import { Course } from '../entities/course.entity';
+
+@Controller('courses')
+export class CoursesController {
+  constructor(private readonly coursesService: CoursesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(
+    @Body() createCourseDto: { title: string; description?: string },
+  ): Promise<Course> {
+    return this.coursesService.create(createCourseDto);
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  findAll(): Promise<Course[]> {
+    return this.coursesService.findAll();
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Course> {
+    return this.coursesService.findOne(id);
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateCourseDto: { title?: string; description?: string },
+  ): Promise<Course> {
+    return this.coursesService.update(id, updateCourseDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.coursesService.remove(id);
+  }
+}

--- a/src/courses/courses.module.ts
+++ b/src/courses/courses.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Course } from '../entities/course.entity';
+import { CoursesService } from './courses.service';
+import { CoursesController } from './courses.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Course])],
+  controllers: [CoursesController],
+  providers: [CoursesService],
+  exports: [CoursesService],
+})
+export class CoursesModule {}

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Course } from '../entities/course.entity';
+
+@Injectable()
+export class CoursesService {
+  constructor(
+    @InjectRepository(Course)
+    private readonly courseRepository: Repository<Course>,
+  ) {}
+
+  async create(createCourseDto: {
+    title: string;
+    description?: string;
+  }): Promise<Course> {
+    const course = this.courseRepository.create(createCourseDto);
+    return await this.courseRepository.save(course);
+  }
+
+  async findAll(): Promise<Course[]> {
+    return await this.courseRepository.find({
+      relations: ['modules', 'modules.lessons'],
+    });
+  }
+
+  async findOne(id: string): Promise<Course> {
+    const course = await this.courseRepository.findOne({
+      where: { id },
+      relations: ['modules', 'modules.lessons'],
+    });
+
+    if (!course) {
+      throw new NotFoundException(`Course with ID ${id} not found`);
+    }
+
+    return course;
+  }
+
+  async update(
+    id: string,
+    updateCourseDto: { title?: string; description?: string },
+  ): Promise<Course> {
+    const course = await this.findOne(id);
+    Object.assign(course, updateCourseDto);
+    return await this.courseRepository.save(course);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.courseRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Course with ID ${id} not found`);
+    }
+  }
+}

--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Module } from './module.entity';
+
+@Entity('courses')
+export class Course {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @OneToMany(() => Module, (module) => module.course)
+  modules: Module[];
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/entities/lesson.entity.ts
+++ b/src/entities/lesson.entity.ts
@@ -1,6 +1,21 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { Reference } from './reference.entity';
 import { Module } from './module.entity';
+
+export enum LessonType {
+  TEXT = 'text',
+  VIDEO = 'video',
+  QUIZ = 'quiz',
+}
 
 @Entity('lessons')
 export class Lesson {
@@ -13,19 +28,26 @@ export class Lesson {
   @Column({ type: 'text', nullable: true })
   content: string;
 
+  @Column({
+    type: 'enum',
+    enum: LessonType,
+    default: LessonType.TEXT,
+  })
+  type: LessonType;
+
   @Column({ nullable: true })
   module_id: string;
 
-  @ManyToOne(() => Module, module => module.lessons)
+  @ManyToOne(() => Module, (module) => module.lessons)
   @JoinColumn({ name: 'module_id' })
   module: Module;
 
-  @OneToMany(() => Reference, reference => reference.lesson)
+  @OneToMany(() => Reference, (reference) => reference.lesson)
   references: Reference[];
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @CreateDateColumn()
   created_at: Date;
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  @UpdateDateColumn()
   updated_at: Date;
-} 
+}

--- a/src/entities/module.entity.ts
+++ b/src/entities/module.entity.ts
@@ -5,7 +5,10 @@ import {
   OneToMany,
   ManyToOne,
   JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
+import { Course } from './course.entity';
 import { Lesson } from './lesson.entity';
 
 @Entity('modules')
@@ -22,10 +25,16 @@ export class Module {
   @Column({ nullable: true })
   course_id: string;
 
-  @ManyToOne('Course')
+  @ManyToOne(() => Course, (course) => course.modules)
   @JoinColumn({ name: 'course_id' })
-  course: any;
+  course: Course;
 
   @OneToMany(() => Lesson, (lesson) => lesson.module)
   lessons: Lesson[];
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
 }

--- a/src/entities/module.entity.ts
+++ b/src/entities/module.entity.ts
@@ -1,5 +1,11 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
-import { Reference } from './reference.entity';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { Lesson } from './lesson.entity';
 
 @Entity('modules')
@@ -13,19 +19,13 @@ export class Module {
   @Column({ type: 'text', nullable: true })
   description: string;
 
-  @OneToMany(() => Reference, (reference) => reference.module)
-  references: Reference[];
+  @Column({ nullable: true })
+  course_id: string;
+
+  @ManyToOne('Course')
+  @JoinColumn({ name: 'course_id' })
+  course: any;
 
   @OneToMany(() => Lesson, (lesson) => lesson.module)
   lessons: Lesson[];
-
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
-  created_at: Date;
-
-  @Column({
-    type: 'timestamp',
-    default: () => 'CURRENT_TIMESTAMP',
-    onUpdate: 'CURRENT_TIMESTAMP',
-  })
-  updated_at: Date;
 }

--- a/src/lessons/lessons.controller.ts
+++ b/src/lessons/lessons.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Put,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { LessonsService } from './lessons.service';
+import { Lesson, LessonType } from '../entities/lesson.entity';
+
+@Controller('lessons')
+export class LessonsController {
+  constructor(private readonly lessonsService: LessonsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(
+    @Body()
+    createLessonDto: {
+      title: string;
+      content?: string;
+      type: LessonType;
+      module_id: string;
+    },
+  ): Promise<Lesson> {
+    return this.lessonsService.create(createLessonDto);
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  findAll(): Promise<Lesson[]> {
+    return this.lessonsService.findAll();
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Lesson> {
+    return this.lessonsService.findOne(id);
+  }
+
+  @Get('module/:moduleId')
+  @HttpCode(HttpStatus.OK)
+  findByModule(
+    @Param('moduleId', ParseUUIDPipe) moduleId: string,
+  ): Promise<Lesson[]> {
+    return this.lessonsService.findByModule(moduleId);
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body()
+    updateLessonDto: {
+      title?: string;
+      content?: string;
+      type?: LessonType;
+    },
+  ): Promise<Lesson> {
+    return this.lessonsService.update(id, updateLessonDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.lessonsService.remove(id);
+  }
+}

--- a/src/lessons/lessons.module.ts
+++ b/src/lessons/lessons.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Lesson } from '../entities/lesson.entity';
+import { LessonsService } from './lessons.service';
+import { LessonsController } from './lessons.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Lesson])],
+  controllers: [LessonsController],
+  providers: [LessonsService],
+  exports: [LessonsService],
+})
+export class LessonsModule {}

--- a/src/lessons/lessons.service.ts
+++ b/src/lessons/lessons.service.ts
@@ -1,0 +1,68 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Lesson, LessonType } from '../entities/lesson.entity';
+
+@Injectable()
+export class LessonsService {
+  constructor(
+    @InjectRepository(Lesson)
+    private readonly lessonRepository: Repository<Lesson>,
+  ) {}
+
+  async create(createLessonDto: {
+    title: string;
+    content?: string;
+    type: LessonType;
+    module_id: string;
+  }): Promise<Lesson> {
+    const lesson = this.lessonRepository.create(createLessonDto);
+    return await this.lessonRepository.save(lesson);
+  }
+
+  async findAll(): Promise<Lesson[]> {
+    return await this.lessonRepository.find({
+      relations: ['module', 'references'],
+    });
+  }
+
+  async findOne(id: string): Promise<Lesson> {
+    const lesson = await this.lessonRepository.findOne({
+      where: { id },
+      relations: ['module', 'references'],
+    });
+
+    if (!lesson) {
+      throw new NotFoundException(`Lesson with ID ${id} not found`);
+    }
+
+    return lesson;
+  }
+
+  async findByModule(moduleId: string): Promise<Lesson[]> {
+    return await this.lessonRepository.find({
+      where: { module_id: moduleId },
+      relations: ['references'],
+    });
+  }
+
+  async update(
+    id: string,
+    updateLessonDto: {
+      title?: string;
+      content?: string;
+      type?: LessonType;
+    },
+  ): Promise<Lesson> {
+    const lesson = await this.findOne(id);
+    Object.assign(lesson, updateLessonDto);
+    return await this.lessonRepository.save(lesson);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.lessonRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Lesson with ID ${id} not found`);
+    }
+  }
+}

--- a/src/modules/modules.controller.ts
+++ b/src/modules/modules.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Put,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ModulesService } from './modules.service';
+import { Module } from '../entities/module.entity';
+
+@Controller('modules')
+export class ModulesController {
+  constructor(private readonly modulesService: ModulesService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(
+    @Body()
+    createModuleDto: {
+      title: string;
+      description?: string;
+      course_id: string;
+    },
+  ): Promise<Module> {
+    return this.modulesService.create(createModuleDto);
+  }
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  findAll(): Promise<Module[]> {
+    return this.modulesService.findAll();
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Module> {
+    return this.modulesService.findOne(id);
+  }
+
+  @Get('course/:courseId')
+  @HttpCode(HttpStatus.OK)
+  findByCourse(
+    @Param('courseId', ParseUUIDPipe) courseId: string,
+  ): Promise<Module[]> {
+    return this.modulesService.findByCourse(courseId);
+  }
+
+  @Put(':id')
+  @HttpCode(HttpStatus.OK)
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateModuleDto: { title?: string; description?: string },
+  ): Promise<Module> {
+    return this.modulesService.update(id, updateModuleDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.modulesService.remove(id);
+  }
+}

--- a/src/modules/modules.module.ts
+++ b/src/modules/modules.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module as CourseModule } from '../entities/module.entity';
+import { ModulesService } from './modules.service';
+import { ModulesController } from './modules.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CourseModule])],
+  controllers: [ModulesController],
+  providers: [ModulesService],
+  exports: [ModulesService],
+})
+export class ModulesModule {}

--- a/src/modules/modules.service.ts
+++ b/src/modules/modules.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Module } from '../entities/module.entity';
+
+@Injectable()
+export class ModulesService {
+  constructor(
+    @InjectRepository(Module)
+    private readonly moduleRepository: Repository<Module>,
+  ) {}
+
+  async create(createModuleDto: {
+    title: string;
+    description?: string;
+    course_id: string;
+  }): Promise<Module> {
+    const module = this.moduleRepository.create(createModuleDto);
+    return await this.moduleRepository.save(module);
+  }
+
+  async findAll(): Promise<Module[]> {
+    return await this.moduleRepository.find({
+      relations: ['course', 'lessons'],
+    });
+  }
+
+  async findOne(id: string): Promise<Module> {
+    const module = await this.moduleRepository.findOne({
+      where: { id },
+      relations: ['course', 'lessons'],
+    });
+
+    if (!module) {
+      throw new NotFoundException(`Module with ID ${id} not found`);
+    }
+
+    return module;
+  }
+
+  async findByCourse(courseId: string): Promise<Module[]> {
+    return await this.moduleRepository.find({
+      where: { course_id: courseId },
+      relations: ['lessons'],
+    });
+  }
+
+  async update(
+    id: string,
+    updateModuleDto: { title?: string; description?: string },
+  ): Promise<Module> {
+    const module = await this.findOne(id);
+    Object.assign(module, updateModuleDto);
+    return await this.moduleRepository.save(module);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.moduleRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Module with ID ${id} not found`);
+    }
+  }
+}


### PR DESCRIPTION
# Module and Lesson Entities Implementation

## Description
This PR implements the module and lesson entities with their relationships, establishing a Course → Module → Lesson hierarchy in the database schema.
close #4
## Changes
- Create `module.entity.ts` with:
  - Basic fields (id, title, description)
  - Relationship to Course entity
  - One-to-many relationship with lessons
- Create `lesson.entity.ts` with:
  - Basic fields (id, title, content)
  - Enum for lesson types (text, video, quiz)
  - Many-to-one relationship with modules

## Testing
- Database schema updates correctly
- Relationships are properly established
- Lesson types are correctly validated

