### PR TITLE
feat(entities): add Course entity and wire to Category/Module

### DIFF
--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+  JoinColumn,
+} from 'typeorm';
+import { Category } from './category.entity';
+import { Module } from './module.entity';
+
+@Entity('courses')
+export class Course {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  thumbnail_url: string;
+
+  @Column({ type: 'boolean', default: true })
+  is_published: boolean;
+
+  @ManyToOne(() => Category, (category) => category.courses, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'category_id' })
+  category: Category;
+
+  @Column({ nullable: true })
+  category_id: string;
+
+  @OneToMany(() => Module, (module) => module.course)
+  modules: Module[];
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}


### PR DESCRIPTION
This PR adds Course entities, wires them to Category and Lesson, and includes controllers/services for Module and Lesson. I was to add all according to the issue but turns out some of the entities needed are already there plus services and contollers.

Issue #14 
