### PR TITLE
Add DTO Validation Decorators

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "codium.codeCompletion.enable": false
+}

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -1,6 +1,7 @@
-import { IsString, IsOptional, IsHexColor, IsBoolean } from 'class-validator';
+import { IsString, IsOptional, IsHexColor, IsBoolean, IsNotEmpty } from 'class-validator';
 
 export class CreateCategoryDto {
+  @IsNotEmpty()
   @IsString()
   name: string;
 

--- a/src/enrollment/dto/create-enrollment.dto.ts
+++ b/src/enrollment/dto/create-enrollment.dto.ts
@@ -1,9 +1,13 @@
-import { IsUUID } from 'class-validator';
+import { IsUUID, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateEnrollmentDto {
+  @IsNotEmpty()
+  @IsString()
   @IsUUID()
   userId: string;
 
+  @IsNotEmpty()
+  @IsString()
   @IsUUID()
   courseId: string;
 }

--- a/src/lesson-resources/dto/create-lesson-resource.dto.ts
+++ b/src/lesson-resources/dto/create-lesson-resource.dto.ts
@@ -20,6 +20,7 @@ export class CreateLessonResourceDto {
   description?: string;
 
   @IsNotEmpty()
+  @IsString()
   @IsUUID()
   lesson_id: string;
 }

--- a/src/lessons/dto/create-lesson.dto.ts
+++ b/src/lessons/dto/create-lesson.dto.ts
@@ -1,18 +1,21 @@
-import { IsString, IsOptional, IsUUID, IsEnum } from 'class-validator';
+import { IsString, IsOptional, IsUUID, IsEnum, IsNotEmpty } from 'class-validator';
 import { LessonType } from '../entities/lesson.entity';
 
 export class CreateLessonDto {
+  @IsNotEmpty()
   @IsString()
   title: string;
 
-  @IsString()
   @IsOptional()
+  @IsString()
   content?: string;
 
-  @IsEnum(LessonType)
   @IsOptional()
+  @IsEnum(LessonType)
   type?: LessonType;
 
+  @IsNotEmpty()
+  @IsString()
   @IsUUID()
   module_id: string;
 }

--- a/src/modules/dto/create-module.dto.ts
+++ b/src/modules/dto/create-module.dto.ts
@@ -1,13 +1,16 @@
-import { IsString, IsOptional, IsUUID } from 'class-validator';
+import { IsString, IsOptional, IsUUID, IsNotEmpty } from 'class-validator';
 
 export class CreateModuleDto {
+  @IsNotEmpty()
   @IsString()
   title: string;
 
-  @IsString()
   @IsOptional()
+  @IsString()
   description?: string;
 
+  @IsNotEmpty()
+  @IsString()
   @IsUUID()
   course_id: string;
 }

--- a/src/quiz/dto/create-quiz.dto.ts
+++ b/src/quiz/dto/create-quiz.dto.ts
@@ -19,6 +19,7 @@ export class CreateQuizDto {
   description?: string;
 
   @IsNotEmpty()
+  @IsString()
   @IsUUID()
   lesson_id: string;
 

--- a/src/references/dto/create-reference.dto.ts
+++ b/src/references/dto/create-reference.dto.ts
@@ -1,20 +1,26 @@
-import { IsString, IsOptional, IsUUID, IsUrl } from 'class-validator';
+import { IsString, IsOptional, IsUUID, IsUrl, IsNotEmpty } from 'class-validator';
 
 export class CreateReferenceDto {
+  @IsNotEmpty()
   @IsString()
   title: string;
 
+  @IsNotEmpty()
+  @IsString()
   @IsUrl({}, { message: 'file_url must be a valid URL' })
   file_url: string;
 
+  @IsNotEmpty()
   @IsString()
   type: string;
 
   @IsOptional()
+  @IsString()
   @IsUUID()
   module_id?: string;
 
   @IsOptional()
+  @IsString()
   @IsUUID()
   lesson_id?: string;
 }

--- a/src/reviews/dto/create-review.dto.ts
+++ b/src/reviews/dto/create-review.dto.ts
@@ -1,10 +1,17 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsString, IsInt, Min, Max, IsOptional } from 'class-validator';
 
 export class CreateReviewDto {
+  @IsOptional()
+  @IsString()
   title?: string;
 
+  @IsOptional()
+  @IsString()
   content?: string;
 
   @IsNotEmpty()
+  @IsInt()
+  @Min(1)
+  @Max(5)
   rating: number;
 }

--- a/src/reviews/dto/update-review.dto.ts
+++ b/src/reviews/dto/update-review.dto.ts
@@ -1,12 +1,16 @@
-import { IsNotEmpty, Max, Min } from "class-validator"
+import { IsNotEmpty, IsString, IsInt, Max, Min, IsOptional } from "class-validator"
 
 export class UpdateReviewDto {
-
+    @IsOptional()
+    @IsString()
     title?: string
 
+    @IsOptional()
+    @IsString()
     content?: string
 
     @IsNotEmpty()
+    @IsInt()
     @Max(5)
     @Min(1)
     rating: number


### PR DESCRIPTION
This PR introduces validation decorators to ensure the integrity of incoming request data. Specifically:

Added @IsString() for string-based fields.

Added @IsInt() for numeric fields.

Added @IsNotEmpty() for required fields.

These decorators were applied to relevant DTOs across the controllers.

closes #39