### PR TITLE
Fix: Add Pagination Parameters Modules

### DIFF
--- a/pagination.md
+++ b/pagination.md
@@ -1,0 +1,100 @@
+**Plan (high level)**
+- Add a small DTO for pagination parameters (transform strings to numbers and validate).
+- Update `modules.controller.ts` GET handlers to accept the DTO and pass it to the service.
+- Update `modules.service.ts` (or repository) to use `page`/`limit` to compute `skip` and `take` and perform the query (prefer `findAndCount` if you need total).
+- Return items plus pagination metadata (page, limit, total or hasMore).
+- Add/update tests and docs.
+
+Step-by-step instructions
+
+1) Create a pagination DTO (recommended location)
+- File: `src/common/dto/pagination-query.dto.ts` (or `src/modules/dto/pagination-query.dto.ts` if you prefer module-scoped).
+- Purpose: accept `page` and `limit` from query, convert to numbers, and validate defaults and ranges.
+- Implementation notes:
+  - Use `class-transformer`'s `@Type(() => Number)` or Nest's `ParseIntPipe` downstream.
+  - Use `class-validator` decorators:
+    - `@IsOptional()`
+    - `@IsInt()`
+    - `@Min(1)` for `page`
+    - `@Min(1)`, `@Max(100)` for `limit` (choose a sensible max)
+  - Provide defaults (e.g., `page = 1`, `limit = 20`) either in the DTO or in controller defaults.
+
+2) Update the controller to accept the DTO and validate
+- Open modules.controller.ts.
+- Import the DTO and add `@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))` to the controller or method. Alternatively, use global validation pipe if your app already has it (likely already set in `main.ts`).
+- Update the GET handler signature:
+  - Before: `findAll()` or `getModules()`
+  - After example: 
+    - `@Get()`
+    - `findAll(@Query() pagination: PaginationQueryDto) { return this.modulesService.findAll(pagination); }`
+- If you prefer simpler pipes without DTO:
+  - Use `@Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number`
+  - Use `@Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number`
+  - But the DTO approach centralizes validation.
+
+3) Update the service to accept pagination and apply skip/take
+- Open modules.service.ts.
+- Add parameters to the `findAll` method: `findAll(pagination: PaginationQueryDto)` or `(page: number, limit: number)`.
+- Compute `skip = (page - 1) * limit`, `take = limit`.
+- If using TypeORM repository:
+  - Simple: `const [items, total] = await this.moduleRepository.findAndCount({ skip, take, order: { createdAt: 'DESC' }});`
+  - If not using `findAndCount`, you can run query builder:
+    - `const items = await this.moduleRepository.createQueryBuilder('m').orderBy('m.createdAt', 'DESC').skip(skip).take(take).getMany();`
+    - To get total count: `.getCount()` or `.getManyAndCount()`.
+- Return a shaped response:
+  - `return { items, meta: { page, limit, total, hasMore: skip + items.length < total } }`
+  - If you don't want to do `total` (expensive), return `items` with `{ nextPage: page + 1, hasMore: items.length === limit }`.
+
+4) Update repository (if you have a dedicated repository file)
+- If entities and `src/modules/modules.repository.ts` exist, move DB logic there. The service calls the repository with `{ skip, take }`.
+
+5) Add tests
+- Update `src/modules/modules.controller.spec.ts` (or create) to call the `GET /modules?limit=2&page=2` and mock the service to confirm it receives `(page, limit)` and returns expected subset.
+- Add service-level tests to assert correct `skip/take` calculations and repository call.
+
+6) Add documentation
+- Update module README or central API docs to include `?page` and `?limit` examples and default/max values.
+
+7) Edge cases & best-practices
+- Enforce maximum `limit` (e.g., 100) to avoid huge responses.
+- Use `transform: true` for DTOs so strings in query convert to numbers automatically.
+- Consider cursor-based pagination if the dataset is large or frequently changing.
+- Return consistent ordering (always specify `orderBy`) so paging is repeatable.
+
+Example code snippets (concise)
+
+- DTO (using `class-validator` + transform):
+  - class PaginationQueryDto {
+      @IsOptional()
+      @Type(() => Number)
+      @IsInt()
+      @Min(1)
+      page?: number = 1;
+
+      @IsOptional()
+      @Type(() => Number)
+      @IsInt()
+      @Min(1)
+      @Max(100)
+      limit?: number = 20;
+    }
+
+- Controller method (method-level snippet):
+  - @Get()
+    findAll(@Query() pagination: PaginationQueryDto) {
+      return this.modulesService.findAll(pagination);
+    }
+
+- Service logic (method-level snippet):
+  - async findAll({ page = 1, limit = 20 }: PaginationQueryDto) {
+      const skip = (page - 1) * limit;
+      const [items, total] = await this.moduleRepository.findAndCount({ skip, take: limit, order: { createdAt: 'DESC' }});
+      return { items, meta: { page, limit, total, hasMore: skip + items.length < total } };
+    }
+
+What to run & check
+- Run unit tests: `npm test` (or your repo's test command).
+- Verify controller validation: request `GET /modules?page=abc` should return a 400 validation error.
+
+Wrap-up / Next step for me
+- I already created a todo plan. If you want, I can implement this for the `modules` endpoints now: create the DTO, patch the controller and service, and add a unit test. Tell me to proceed and whether you prefer DTO-based or direct pipes approach.

--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,18 @@
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/modules/dto/paginated-module-response.dto.ts
+++ b/src/modules/dto/paginated-module-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ModuleResponseDto } from './module-response.dto';
+
+class PaginationMetaDto {
+  @ApiProperty({ example: 1, description: 'Current page number' })
+  page: number;
+
+  @ApiProperty({ example: 10, description: 'Number of items per page' })
+  limit: number;
+
+  @ApiProperty({ example: 100, description: 'Total number of items available' })
+  total: number;
+
+  @ApiProperty({ example: true, description: 'Indicates if there are more pages available' })
+  hasMore: boolean;
+}
+
+export class PaginatedModuleResponseDto {
+  @ApiProperty({ isArray: true, type: ModuleResponseDto })
+  items: ModuleResponseDto[];
+
+  @ApiProperty({ type: () => PaginationMetaDto })
+  meta: PaginationMetaDto;
+}

--- a/src/modules/modules.controller.spec.ts
+++ b/src/modules/modules.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ModulesController } from './modules.controller';
+import { ModulesService } from './modules.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { AuthGuard } from '../common/guards/auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+
+describe('ModulesController', () => {
+  let controller: ModulesController;
+  let service: jest.Mocked<ModulesService>;
+
+  const mockModulesService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    findByCourseId: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ModulesController],
+      providers: [
+        {
+          provide: ModulesService,
+          useValue: mockModulesService,
+        },
+      ],
+    })
+    .overrideGuard(AuthGuard).useValue({ canActivate: () => true })
+    .overrideGuard(RolesGuard).useValue({ canActivate: () => true })
+    .compile();
+
+    controller = module.get<ModulesController>(ModulesController);
+    service = module.get(ModulesService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should call service with pagination query and return paginated results', async () => {
+      const paginationQuery: PaginationQueryDto = { page: 2, limit: 10 };
+      const mockPaginatedResult = { 
+        items: [], 
+        meta: { page: 2, limit: 10, total: 0, hasMore: false } 
+      };
+
+      service.findAll.mockResolvedValue(mockPaginatedResult);
+
+      const result = await controller.findAll(paginationQuery);
+
+      expect(service.findAll).toHaveBeenCalledWith(paginationQuery);
+      expect(result).toEqual(mockPaginatedResult);
+    });
+  });
+
+  describe('findByCourseId', () => {
+    it('should call service with courseId and pagination query', async () => {
+      const courseId = 'some-course-id';
+      const paginationQuery: PaginationQueryDto = { page: 1, limit: 5 };
+      const mockPaginatedResult = { 
+        items: [], 
+        meta: { page: 1, limit: 5, total: 0, hasMore: false } 
+      };
+
+      service.findByCourseId.mockResolvedValue(mockPaginatedResult);
+
+      const result = await controller.findByCourseId(courseId, paginationQuery);
+
+      expect(service.findByCourseId).toHaveBeenCalledWith(courseId, paginationQuery);
+      expect(result).toEqual(mockPaginatedResult);
+    });
+  });
+});

--- a/src/modules/modules.controller.ts
+++ b/src/modules/modules.controller.ts
@@ -7,18 +7,20 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Roles } from '../common/decorators/roles.decorator';
 import { AuthGuard } from '../common/guards/auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { UserRole } from '../users/entities/user.entity';
 import { CreateModuleDto } from './dto/create-module.dto';
 import { UpdateModuleDto } from './dto/update-module.dto';
-import { Module } from './entities/module.entity';
 import { ModuleResponseDto } from './dto/module-response.dto';
 import { ModulesService } from './modules.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { PaginatedModuleResponseDto } from './dto/paginated-module-response.dto';
 
 
 @Controller('modules')
@@ -29,26 +31,38 @@ export class ModulesController {
   constructor(private readonly modulesService: ModulesService) {}
 
   @Post()
+  @ApiResponse({ status: 201, description: 'The module has been successfully created.', type: ModuleResponseDto })
   async create(@Body() createModuleDto: CreateModuleDto): Promise<ModuleResponseDto> {
     return await this.modulesService.create(createModuleDto);
   }
 
   @Get()
-  async findAll(): Promise<ModuleResponseDto[]> {
-    return await this.modulesService.findAll();
+  @ApiResponse({ status: 200, description: 'A paginated list of modules.', type: PaginatedModuleResponseDto })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number for pagination. Defaults to 1.', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page. Defaults to 20, max 100.', example: 10 })
+  async findAll(@Query() pagination: PaginationQueryDto): Promise<PaginatedModuleResponseDto> {
+    return await this.modulesService.findAll(pagination);
   }
 
   @Get(':id')
+  @ApiResponse({ status: 200, description: 'A single module.', type: ModuleResponseDto })
   async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<ModuleResponseDto> {
     return await this.modulesService.findOne(id);
   }
 
   @Get('course/:courseId')
-  async findByCourseId(@Param('courseId', ParseUUIDPipe) courseId: string): Promise<ModuleResponseDto[]> {
-    return this.modulesService.findByCourseId(courseId);
+  @ApiResponse({ status: 200, description: 'A paginated list of modules for a course.', type: PaginatedModuleResponseDto })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number for pagination. Defaults to 1.', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page. Defaults to 20, max 100.', example: 10 })
+  async findByCourseId(
+    @Param('courseId', ParseUUIDPipe) courseId: string,
+    @Query() pagination: PaginationQueryDto,
+  ): Promise<PaginatedModuleResponseDto> {
+    return this.modulesService.findByCourseId(courseId, pagination);
   }
 
   @Patch(':id')
+  @ApiResponse({ status: 200, description: 'The module has been successfully updated.', type: ModuleResponseDto })
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateModuleDto: UpdateModuleDto,
@@ -57,6 +71,7 @@ export class ModulesController {
   }
 
   @Delete(':id')
+  @ApiResponse({ status: 204, description: 'The module has been successfully deleted.' })
   async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return await this.modulesService.remove(id);
   }

--- a/src/modules/modules.service.spec.ts
+++ b/src/modules/modules.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ModulesService } from './modules.service';
+import { Module } from './entities/module.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+
+type MockRepository = Partial<Record<keyof Repository<Module>, jest.Mock>>;
+
+const createMockRepository = (): MockRepository => ({
+  findAndCount: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+
+describe('ModulesService', () => {
+  let service: ModulesService;
+  let moduleRepository: MockRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ModulesService,
+        {
+          provide: getRepositoryToken(Module),
+          useValue: createMockRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<ModulesService>(ModulesService);
+    moduleRepository = module.get<MockRepository>(getRepositoryToken(Module));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return paginated modules and metadata', async () => {
+      const paginationQuery: PaginationQueryDto = { page: 2, limit: 5 };
+      const mockModules = [{ id: '1', title: 'Test Module' }] as Module[];
+      const total = 12;
+      const skip = (paginationQuery.page! - 1) * paginationQuery.limit!;
+      const take = paginationQuery.limit!;
+
+      moduleRepository.findAndCount!.mockResolvedValue([mockModules, total]);
+
+      const result = await service.findAll(paginationQuery);
+
+      expect(moduleRepository.findAndCount).toHaveBeenCalledWith({
+        relations: ['course', 'lessons'],
+        skip,
+        take,
+        order: { created_at: 'DESC' },
+      });
+
+      expect(result.items.length).toBe(mockModules.length);
+      expect(result.meta.total).toBe(total);
+      expect(result.meta.page).toBe(paginationQuery.page);
+      expect(result.meta.limit).toBe(paginationQuery.limit);
+      expect(result.meta.hasMore).toBe(true);
+    });
+  });
+
+  describe('findByCourseId', () => {
+    it('should return paginated modules for a given courseId', async () => {
+      const courseId = 'test-course-id';
+      const paginationQuery: PaginationQueryDto = { page: 1, limit: 10 };
+      const mockModules = [
+        { id: '1', title: 'Module 1' },
+        { id: '2', title: 'Module 2' },
+      ] as Module[];
+      const total = 2;
+      const skip = (paginationQuery.page! - 1) * paginationQuery.limit!;
+      const take = paginationQuery.limit!;
+
+      moduleRepository.findAndCount!.mockResolvedValue([mockModules, total]);
+
+      const result = await service.findByCourseId(courseId, paginationQuery);
+
+      expect(moduleRepository.findAndCount).toHaveBeenCalledWith({
+        where: { course_id: courseId },
+        relations: ['lessons'],
+        order: { created_at: 'ASC' },
+        skip,
+        take,
+      });
+
+      expect(result.items.length).toBe(mockModules.length);
+      expect(result.meta.total).toBe(total);
+      expect(result.meta.page).toBe(paginationQuery.page);
+      expect(result.meta.limit).toBe(paginationQuery.limit);
+      expect(result.meta.hasMore).toBe(false);
+    });
+  });
+});

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Course } from "../../courses/entities/course.entity"
+import { UserRole } from '../enums/user-role.enum';
 export { UserRole } from '../enums/user-role.enum';
 import { Review } from 'src/reviews/entities/reviews.entity';
 import {


### PR DESCRIPTION
# Closes #45 
### feat(modules): Add pagination to GET modules endpoints

  #### Description


  This PR introduces pagination to the primary GET endpoints for the modules feature (GET /modules and GET
  /modules/course/:courseId). Previously, these endpoints would return all modules at once, which could lead to
  performance issues and large response payloads as the number of modules grows. By implementing pagination, we allow
  clients to request data in manageable chunks, improving both performance and API usability.