### PR TITLE
Fix Category Service functions to have descriptive names

### DIFF
--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -13,7 +13,7 @@ import { UpdateCategoryDto } from './dto/update-category.dto';
 export class CategoriesService {
   constructor(private readonly categoriesRepository: CategoriesRepository) {}
 
-  async create(createCategoryDto: CreateCategoryDto): Promise<Category> {
+  async createCategory(createCategoryDto: CreateCategoryDto): Promise<Category> {
     // Check if category name already exists
     const nameExists = await this.categoriesRepository.nameExists(
       createCategoryDto.name,
@@ -29,7 +29,7 @@ export class CategoriesService {
     return await this.categoriesRepository.findAll();
   }
 
-  async findById(id: string): Promise<Category> {
+  async findCategoryById(id: string): Promise<Category> {
     if (!id) {
       throw new BadRequestException('Category ID is required');
     }
@@ -42,7 +42,7 @@ export class CategoriesService {
     return category;
   }
 
-  async update(
+  async updateCategory(
     id: string,
     updateCategoryDto: UpdateCategoryDto,
   ): Promise<Category> {
@@ -78,7 +78,7 @@ export class CategoriesService {
     return updatedCategory;
   }
 
-  async delete(id: string): Promise<void> {
+  async deleteCategory(id: string): Promise<void> {
     if (!id) {
       throw new BadRequestException('Category ID is required');
     }
@@ -110,7 +110,7 @@ export class CategoriesService {
     return await this.categoriesRepository.findActiveCategories();
   }
 
-  async getCoursesCount(id: string): Promise<number> {
+  async getCategoryCoursesCount(id: string): Promise<number> {
     if (!id) {
       throw new BadRequestException('Category ID is required');
     }

--- a/src/categories/dto/update-category.dto.ts
+++ b/src/categories/dto/update-category.dto.ts
@@ -1,4 +1,6 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateCategoryDto } from './create-category.dto';
 
-export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {
+  name: string;
+}


### PR DESCRIPTION
With this PR the file `src/cateogories/category.service.ts` has a refactor of the funtions to keep a structure name convention