### PR TITLE
edit: rename plural variables

### DIFF
--- a/src/answer/answer.module.ts
+++ b/src/answer/answer.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Answer } from './entities/answer.entity';
+import { Answers } from './entities/answers.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Answer])],
+  imports: [TypeOrmModule.forFeature([Answers])],
   exports: [TypeOrmModule],
 })
-export class AnswerModule {}
+export class AnswersModule {}

--- a/src/answer/entities/answers.entity.ts
+++ b/src/answer/entities/answers.entity.ts
@@ -10,7 +10,7 @@ import {
 import { Question } from '../../question/entities/question.entity';
 
 @Entity('answers')
-export class Answer {
+export class Answers {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/src/question/entities/question.entity.ts
+++ b/src/question/entities/question.entity.ts
@@ -8,7 +8,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { Answer } from '../../answer/entities/answer.entity';
+import { Answer } from '../../answer/entities/answers.entity';
 import { Quiz } from '../../quiz/entities/quiz.entity';
 
 export enum QuestionType {

--- a/src/quiz/entities/user-question-response.entity.ts
+++ b/src/quiz/entities/user-question-response.entity.ts
@@ -9,7 +9,7 @@ import {
 } from 'typeorm';
 import { QuizAttempt } from './quiz-attempt.entity';
 import { Question } from '../../question/entities/question.entity';
-import { Answer } from '../../answer/entities/answer.entity';
+import { Answer } from '../../answer/entities/answers.entity';
 
 @Entity('user_question_responses')
 export class UserQuestionResponse {

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Answer } from '../answer/entities/answer.entity';
+import { Answer } from '../answer/entities/answers.entity';
 import { Question } from '../question/entities/question.entity';
 import { Quiz } from './entities/quiz.entity';
 import { QuizController } from './quiz.controller';

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Answer } from '../answer/entities/answer.entity';
+import { Answer } from '../answer/entities/answers.entity';
 import { CentralizedLoggerService } from '../common/logger/services/centralized-logger.service';
 import { Question, QuestionType } from '../question/entities/question.entity';
 import { User } from '../users/entities/user.entity';


### PR DESCRIPTION
Close: #99 

- Renamed Answer → Answers
- Renamed AnswerModule → AnswersModule
- Updated imports to ./entities/answers.entity
- Renamed files to answers.module.ts and answers.entity.ts

Reason: maintain consistent plural naming convention and improve readability.