### PR TITLE
Implement Course Management REST API (#206)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10547,6 +10547,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",

--- a/src/courses/courses.repository.ts
+++ b/src/courses/courses.repository.ts
@@ -50,10 +50,14 @@ export class CoursesRepository {
         'course.id',
         'course.title',
         'course.description',
+        'course.thumbnailUrl',
+        'course.language',
+        'course.syllabus',
         'course.professorId',
         'course.categoryId',
         'course.createdAt',
         'course.updatedAt',
+        'course.isPublished',
         'professor.id',
         'professor.name',
         'professor.email',
@@ -61,6 +65,7 @@ export class CoursesRepository {
         'category.name',
         'category.color',
       ])
+      .where('course.isPublished = :isPublished', { isPublished: true })
       .orderBy('course.createdAt', 'DESC');
 
     if (filters) {
@@ -84,10 +89,14 @@ export class CoursesRepository {
         id: true,
         title: true,
         description: true,
+        thumbnailUrl: true,
+        language: true,
+        syllabus: true,
         professorId: true,
         categoryId: true,
         createdAt: true,
         updatedAt: true,
+        isPublished: true,
         professor: {
           id: true,
           name: true,
@@ -110,10 +119,14 @@ export class CoursesRepository {
         id: true,
         title: true,
         description: true,
+        thumbnailUrl: true,
+        language: true,
+        syllabus: true,
         professorId: true,
         categoryId: true,
         createdAt: true,
         updatedAt: true,
+        isPublished: true,
         professor: {
           id: true,
           name: true,
@@ -170,10 +183,14 @@ export class CoursesRepository {
         id: true,
         title: true,
         description: true,
+        thumbnailUrl: true,
+        language: true,
+        syllabus: true,
         professorId: true,
         categoryId: true,
         createdAt: true,
         updatedAt: true,
+        isPublished: true,
         professor: {
           id: true,
           name: true,
@@ -210,14 +227,19 @@ export class CoursesRepository {
       .leftJoinAndSelect('course.professor', 'professor')
       .leftJoinAndSelect('course.category', 'category')
       .where('course.categoryId = :categoryId', { categoryId })
+      .andWhere('course.isPublished = :isPublished', { isPublished: true })
       .select([
         'course.id',
         'course.title',
         'course.description',
+        'course.thumbnailUrl',
+        'course.language',
+        'course.syllabus',
         'course.professorId',
         'course.categoryId',
         'course.createdAt',
         'course.updatedAt',
+        'course.isPublished',
         'professor.id',
         'professor.name',
         'professor.email',

--- a/src/courses/dto/course-response.dto.ts
+++ b/src/courses/dto/course-response.dto.ts
@@ -14,6 +14,21 @@ export class CourseResponseDto {
   @ApiProperty({ required: false })
   description?: string;
 
+  @ApiProperty({ required: false, description: 'Public thumbnail URL for the course' })
+  thumbnailUrl?: string | null;
+
+  @ApiProperty({
+    required: false,
+    description: 'Language code for the course content (e.g. en, fr)',
+  })
+  language?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Extended syllabus/outline text for the course',
+  })
+  syllabus?: string | null;
+
   @ApiProperty({ type: UserResponseDto })
   professor: UserResponseDto;
 
@@ -31,4 +46,10 @@ export class CourseResponseDto {
 
   @ApiProperty({ type: Number, default: 0 })
   averageRating: number;
+
+  @ApiProperty({
+    description:
+      'Whether the course is published and visible in public course listings',
+  })
+  isPublished: boolean;
 }

--- a/src/courses/dto/create-course.dto.ts
+++ b/src/courses/dto/create-course.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -18,6 +19,18 @@ export class CreateCourseDto {
   @MinLength(VALIDATION_CONSTRAINTS.COURSE_DESCRIPTION_MIN_LENGTH)
   description: string;
 
+  @IsOptional()
+  @IsString()
+  thumbnailUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @IsOptional()
+  @IsString()
+  syllabus?: string;
+
   @IsNotEmpty()
   @IsString()
   @IsUUID()
@@ -27,4 +40,8 @@ export class CreateCourseDto {
   @IsString()
   @IsUUID()
   categoryId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPublished?: boolean;
 }

--- a/src/courses/dto/update-course.dto.ts
+++ b/src/courses/dto/update-course.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
 import { VALIDATION_CONSTRAINTS } from '../../common/constants';
 
 export class UpdateCourseDto {
@@ -14,6 +14,18 @@ export class UpdateCourseDto {
 
   @IsOptional()
   @IsString()
+  thumbnailUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @IsOptional()
+  @IsString()
+  syllabus?: string;
+
+  @IsOptional()
+  @IsString()
   @IsUUID()
   professorId?: string;
 
@@ -21,4 +33,8 @@ export class UpdateCourseDto {
   @IsString()
   @IsUUID()
   categoryId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPublished?: boolean;
 }

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -10,6 +10,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { COLUMN_LENGTHS } from '../../common/constants';
 import { Enrollment } from '../../enrollment/entities/enrollment.entity';
 import { Category } from '../../entities/category.entity';
 import { Objective } from '../../objectives/entities/objective.entity';
@@ -25,6 +26,24 @@ export class Course {
 
   @Column({ type: 'text' })
   description: string;
+
+  @Column({
+    type: 'varchar',
+    length: COLUMN_LENGTHS.URL,
+    nullable: true,
+    name: 'thumbnail_url',
+  })
+  thumbnailUrl: string | null;
+
+  @Column({
+    type: 'varchar',
+    length: 16,
+    default: 'en',
+  })
+  language: string;
+
+  @Column({ type: 'text', nullable: true })
+  syllabus: string | null;
 
   @Column({ type: 'uuid' })
   professorId: string;
@@ -54,6 +73,9 @@ export class Course {
     eager: false,
   })
   objectives: Objective[];
+
+  @Column({ type: 'boolean', default: true })
+  isPublished: boolean;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/courses/providers/courses.service.ts
+++ b/src/courses/providers/courses.service.ts
@@ -69,6 +69,9 @@ export class CoursesService {
         id: course.id,
         title: course.title,
         description: course.description,
+        thumbnailUrl: course.thumbnailUrl ?? null,
+        language: course.language,
+        syllabus: course.syllabus ?? null,
         professor: {
           id: course.professor.id,
           name: course.professor.name,
@@ -99,6 +102,7 @@ export class CoursesService {
         createdAt: course.createdAt,
         updatedAt: course.updatedAt,
         averageRating: course.acquireReviewAverageRating(),
+        isPublished: course.isPublished,
       })),
       total,
     };


### PR DESCRIPTION
## Summary

- Expose additional off-chain course metadata (thumbnailUrl, language, syllabus, isPublished) on the Course entity and DTOs
- Ensure public course listings and category queries only return published courses while preserving full data for professor/admin views
- Keep existing relations to professor, category, modules, enrollments, and reviews efficient via targeted selects in the repository

## Testing

- npm test

